### PR TITLE
🔧 refactor(setup.py): use classifier instead of license arg and set license to MIT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,9 @@ setup(
         name='Torchelie',
         version='0.1dev',
         packages=find_packages(),
-        license='Creative Commons Attribution-Noncommercial-Share Alike license',
+        classifiers=[
+            "License :: OSI Approved :: MIT License",
+        ],
         install_requires=[
             'visdom>=0.1.8',
             'crayons>=0.2',


### PR DESCRIPTION
As per [the official Python packaging
doc](https://packaging.python.org/guides/distributing-packages-using-setuptools/#license):

> [...]
> If you’re using a standard, well-known license, then your main indication can and should be via the classifiers argument. Classifiers exist for all major open-source licenses.
>
> The “license” argument is more typically used to indicate differences from well-known licenses, or to include your own, unique license. As a general rule, it’s a good idea to use a standard, well-known license, both to avoid confusion and because some organizations avoid software whose license is unapproved.

Since this project is licensed under MIT license, it seems to make more sense to use the existing classifier instead of a custom license argument.

---

Also, this PR makes it so the `setup.py` references the MIT license instead of `Creative Commons Attribution-Noncommercial-Share Alike license`