### PR TITLE
🎨 lint(everything): fix PEP8 warnings about comments format (E262+E265+E261)

### DIFF
--- a/torchelie/data_learning.py
+++ b/torchelie/data_learning.py
@@ -117,7 +117,7 @@ class SpectralImage(LearnableImage):
         """
         Return the image
         """
-        #return self.bite[0].to(self.spectrum_var.device)
+        # return self.bite[0].to(self.spectrum_var.device)
         n, ch, h, w = self.shape
 
         scaled_spectrum = self.spectrum_var * self.spertum_scale

--- a/torchelie/datasets/__init__.py
+++ b/torchelie/datasets/__init__.py
@@ -151,7 +151,7 @@ def mixup(x1, x2, y1, y2, num_classes, mixer=None, alpha=0.4):
 class _Wrap:
     def __init__(self, instance):
         # FIXME: NOT WORKING WHEN SETTING MEMBERS
-        #self.__dict__ = instance.__dict__
+        # self.__dict__ = instance.__dict__
         self.ds = instance
 
     def __getattr__(self, attr):

--- a/torchelie/loss/neuralstyleloss.py
+++ b/torchelie/loss/neuralstyleloss.py
@@ -20,24 +20,24 @@ def hist_match(source, template):
     RES = 256
     ssz = (sM - sm) / (RES - 1)
     tsz = (tM - tm) / (RES - 1)
-    #s_counts, s_values = np.histogram(source, bins=256, range=(m, M))
-    #t_counts, t_values = np.histogram(template, bins=256, range=(m, M))
+    # s_counts, s_values = np.histogram(source, bins=256, range=(m, M))
+    # t_counts, t_values = np.histogram(template, bins=256, range=(m, M))
     s_counts = torch.histc(source, bins=RES, min=sm, max=sM)
     t_counts = torch.histc(template, bins=RES, min=tm, max=tM)
 
     # take the cumsum of the counts and normalize by the number of pixels to
     # get the empirical cumulative distribution functions for the source and
     # template images (maps pixel value --> quantile)
-    #s_quantiles = np.cumsum(s_counts).astype(np.float64)
+    # s_quantiles = np.cumsum(s_counts).astype(np.float64)
     s_quantiles = torch.cumsum(s_counts, dim=0).float()
     s_quantiles /= s_quantiles[-1].clone()
-    #t_quantiles = np.cumsum(t_counts).astype(np.float64)
+    # t_quantiles = np.cumsum(t_counts).astype(np.float64)
     t_quantiles = torch.cumsum(t_counts, dim=0).float()
     t_quantiles /= t_quantiles[-1].clone()
 
     # interpolate linearly to find the pixel values in the template image
     # that correspond most closely to the quantiles in the source image
-    #interp_t_values = np.interp(s_quantiles, t_quantiles, t_values[1:])
+    # interp_t_values = np.interp(s_quantiles, t_quantiles, t_values[1:])
     interp_t_values = (t_quantiles[:, None] <
                        s_quantiles[None, :]).sum(0).float().mul_(tsz).add_(tm)
 

--- a/torchelie/models/efficient.py
+++ b/torchelie/models/efficient.py
@@ -67,40 +67,40 @@ class EfficientNet(tnn.CondSeq):
             return int(224 * 1.15**B)
 
         super(EfficientNet, self).__init__(
-            #Stage 1
-            #nn.UpsamplingBilinear2d(size=(r(), r())),
+            # Stage 1
+            # nn.UpsamplingBilinear2d(size=(r(), r())),
             tu.kaiming(tnn.Conv3x3(in_ch, ch(32), stride=2, bias=False)),
             nn.BatchNorm2d(ch(32)),
             tnn.HardSwish(),
 
-            #Stage 2
+            # Stage 2
             MBConv(ch(32), ch(16), 3, mul_factor=1),
             *[
                 MBConv(ch(16), ch(16), 3, mul_factor=1)
                 for _ in range(l(1) - 1)
             ],
 
-            #Stage 3
+            # Stage 3
             MBConv(ch(16), ch(24), 3, stride=2),
             *[MBConv(ch(24), ch(24), 3) for _ in range(l(2) - 1)],
 
-            #Stage 4
+            # Stage 4
             MBConv(ch(24), ch(40), 5, stride=2),
             *[MBConv(ch(40), ch(40), 5) for _ in range(l(2) - 1)],
 
-            #Stage 5
+            # Stage 5
             MBConv(ch(40), ch(80), 3, stride=2),
             *[MBConv(ch(80), ch(80), 3) for _ in range(l(3) - 1)],
 
-            #Stage 6
+            # Stage 6
             MBConv(ch(80), ch(112), 5),
             *[MBConv(ch(112), ch(112), 5) for _ in range(l(3) - 1)],
 
-            #Stage 7
+            # Stage 7
             MBConv(ch(112), ch(192), 5, stride=2),
             *[MBConv(ch(192), ch(192), 5) for _ in range(l(4) - 1)],
 
-            #Stage 8
+            # Stage 8
             MBConv(ch(192), ch(320), 3),
             *[MBConv(ch(320), ch(320), 3) for _ in range(l(1) - 1)],
             tu.kaiming(tnn.Conv1x1(ch(320), ch(1280), bias=False)),

--- a/torchelie/models/perceptualnet.py
+++ b/torchelie/models/perceptualnet.py
@@ -31,7 +31,7 @@ class PerceptualNet(WithSavedActivations):
             'conv4_1', 'relu4_1', 'conv4_2', 'relu4_2', 'conv4_3', 'relu4_3',
                     'conv4_4', 'relu4_4', 'maxpool4',
             'conv5_1', 'relu5_1', 'conv5_2', 'relu5_2', 'conv5_3', 'relu5_3',
-                    'conv5_4', 'relu5_4',# 'maxpool5'
+                    'conv5_4', 'relu5_4',  # 'maxpool5'
         ]
         # yapf: enable
 

--- a/torchelie/nn/conv.py
+++ b/torchelie/nn/conv.py
@@ -175,7 +175,7 @@ class ConvBlock(CondSeq):
             self
         """
         if hasattr(self.norm, 'bias') and self.norm is not None:
-            self.norm.bias = None  #type: ignore
+            self.norm.bias = None  # type: ignore
         self.conv.bias = None
         return self
 

--- a/torchelie/recipes/stylegan2.py
+++ b/torchelie/recipes/stylegan2.py
@@ -317,7 +317,7 @@ def train(rank, world_size):
     import argparse
 
     parser = argparse.ArgumentParser()
-    #parser.add_argument('--device', default='cuda')
+    # parser.add_argument('--device', default='cuda')
     parser.add_argument('--batch-size', type=int, default=64)
     parser.add_argument('--noise-size', type=int, default=128)
     parser.add_argument('--img-size', type=int, default=64)

--- a/torchelie/recipes/unpaired.py
+++ b/torchelie/recipes/unpaired.py
@@ -44,8 +44,8 @@ class Matcher(nn.Module):
         self.proj_B = tu.kaiming(tnn.Conv1x1(128, self.proj_size), dynamic=True)
 
     def forward(self, fake, ins):
-        #fake = F.interpolate(fake, scale_factor=0.5, mode='bilinear')
-        #ins = F.interpolate(ins, scale_factor=0.5, mode='bilinear')
+        # fake = F.interpolate(fake, scale_factor=0.5, mode='bilinear')
+        # ins = F.interpolate(ins, scale_factor=0.5, mode='bilinear')
         f1 = self.proj_A(self.net(fake))
         f2 = self.proj_B(self.net(ins))
         n, c, h, w = f1.shape
@@ -100,7 +100,7 @@ def train(rank, world_size):
 
     for m in G.modules():
         if isinstance(m, (nn.Conv2d, nn.ConvTranspose2d)):
-            #tu.kaiming(m, a=0.2, dynamic=True)
+            # tu.kaiming(m, a=0.2, dynamic=True)
             weight_norm_and_equal_lr(m, 0.2)
     G.remove_batchnorm()
 
@@ -171,8 +171,8 @@ def train(rank, world_size):
             clf_loss = opts.consistency * M(out * 2 - 1, x * 2 -
                     1)['loss']
 
-        #labels = torch.arange(len(matches), device=matches.device)
-        #clf_loss = opts.consistency * F.cross_entropy( matches, torch.arange(len(matches), device=matches.device))
+        # labels = torch.arange(len(matches), device=matches.device)
+        # clf_loss = opts.consistency * F.cross_entropy( matches, torch.arange(len(matches), device=matches.device))
         clf_loss.backward()
         return {'G_loss': loss.item()}
 
@@ -272,7 +272,7 @@ def train(rank, world_size):
         tch.callbacks.Log('out', 'out'),
         tch.callbacks.Log('batch.0', 'x'),
         tch.callbacks.Log('batch.1', 'y'),
-        #tch.callbacks.Log('batch.0.1', 'y'),
+        # tch.callbacks.Log('batch.0.1', 'y'),
         tch.callbacks.WindowedMetricAvg('fake_loss', 'fake_loss'),
         tch.callbacks.WindowedMetricAvg('real_loss', 'real_loss'),
         tch.callbacks.WindowedMetricAvg('prob_fake', 'prob_fake'),


### PR DESCRIPTION
This PR fixes comment formatting according to [PEP8](https://www.python.org/dev/peps/pep-0008) guidelines.

- At least two spaces before inline comment: [E261](https://www.flake8rules.com/rules/E261.html) / [PEP8#inline-comments](https://www.python.org/dev/peps/pep-0008/#inline-comments)
- Inline comment should start with `# `: [E262](https://www.flake8rules.com/rules/E262.html) / [PEP8#inline-comments](https://www.python.org/dev/peps/pep-0008/#inline-comments)
- Block comment should start with `# `: [E265](https://www.flake8rules.com/rules/E265.html) / [PEP8#block-comments](https://www.python.org/dev/peps/pep-0008/#block-comments)
