### PR TITLE
🐛 fix(nn): export resblock module in nn

### DIFF
--- a/torchelie/nn/__init__.py
+++ b/torchelie/nn/__init__.py
@@ -15,4 +15,5 @@ from .condseq import CondSeq
 from .graph import ModuleGraph
 from .encdec import *
 from .interpolate import *
+from .resblock import *
 import torchelie.nn.utils


### PR DESCRIPTION
Before #11, a bunch of stuff in the `nn` module (such as `ResBlock` and `PreactResBlockBottleneck`) was implicitly exported because they were imported in `blocks` despite not being used there, since all the `blocks` content is exported for `nn`.

However, they are called outside of the `nn` module (i.e. in `models.resnet`).

This fixes this situation by making the `resblock` content explicitly exported in `nn` interface.