### PR TITLE
🐛 test(nn): fix test_blocks() with updated functions/classes

### DIFF
--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -52,7 +52,7 @@ def test_blocks():
     m = Conv2dBNReLU(4, 8, 3)
     m(torch.randn(1, 4, 8, 8))
 
-    m = Conv2dBNReLU(4, 8, 3).remove_bn().leaky()
+    m = Conv2dBNReLU(4, 8, 3).remove_batchnorm().leaky()
     m(torch.randn(1, 4, 8, 8))
 
     m = ResBlock(4, 8, 1)

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -76,7 +76,7 @@ def test_blocks():
     m = AutoGANGenBlock(3, 3, [5])
     m(torch.randn(1, 3, 8, 8), [torch.randn(1, 5, 4, 4)])
 
-    m = SNResidualDiscrBlock(6, 3)
+    m = ResidualDiscrBlock(6, 3)
     m(torch.randn(1, 6, 8, 8))
 
 def test_vq():

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -46,7 +46,7 @@ def test_attnnorm():
 
 
 def test_blocks():
-    m = MConvBNrelu(4, 8, 3)
+    m = MConvBNReLU(4, 8, 3)
     m(torch.randn(1, 4, 8, 8))
 
     m = Conv2dBNReLU(4, 8, 3)


### PR DESCRIPTION
`test_blocks()` was failing because:

- `remove_bn()` was renamed by 09640a49fae6068a9d5f073452bf17dc8bc3f47a into `remove_batchnorm()`
- `SNResidualDiscrBlock` was removed by bcb91b5ba8e0a0795adce7f8535a2176d23cf620 - I used `ResidualDiscrBlock` instead but I'm not sure that's the right thing to do
- Capitalization was wrong on `MConvBNReLU` - guess it was also changed in a previous commit

This PR makes it pass again :slightly_smiling_face: 