### PR TITLE
✅ test(transforms): mark test_canny() as requiring OpenCV so it can be excluded

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,3 +266,13 @@ Modules:
   classification task `argmin L(f(x, z), y)` where `x` is a MNIST sample, `z` a
   class label, and `y = 1` if `z` is the correct label for `x`, 0 otherwise.
 
+## Testing without OpenCV
+
+Since OpenCV is an optional dependency, you might want to run tests in such a
+setup (therefore not testing Canny). You can do so by excluding the
+`require_opencv` [pytest custom
+marker](https://docs.pytest.org/en/stable/example/markers.html) like so:
+
+```shell
+pytest -m "not require_opencv"
+```

--- a/tests/test_tranforms.py
+++ b/tests/test_tranforms.py
@@ -1,4 +1,5 @@
 import torch
+import pytest
 from torchvision.transforms import ToPILImage
 from torchelie.transforms import *
 import torchelie.transforms.differentiable as dtf
@@ -27,6 +28,7 @@ def test_multibranch():
     assert tf(1) == (2, 3, 0)
 
 
+@pytest.mark.require_opencv
 def test_canny():
     img = ToPILImage()(torch.clamp(torch.randn(3, 30, 16) + 1, min=0, max=1))
     tf = Canny()


### PR DESCRIPTION
Since OpenCV is an **optional** dependency, I figured it would be nice to be able to run tests in such a setup (which btw is mine for now).

This PR introduces a `require_opencv` [pytest marker](https://docs.pytest.org/en/stable/example/markers.html) so it can be excluded by running `pytest -m "not require_opencv"`