### PR TITLE
👷 chore(ci): bootstrap GitHub Actions with testing workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: "Torchélie tests"
+
+on: [push, pull_request]
+
+jobs:
+  install-dependencies:
+    name: "Dependencies + Unit tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v2
+      - name: "Cache pip"
+        uses: actions/cache@v2
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      - name: "Set up Python"
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: "Install dependencies"
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r requirements.txt
+      - name: "Run tests with pytest"
+        run: |
+          python -m pytest


### PR DESCRIPTION
Trying to bootstrap some CI here so tests failures are detected early :slightly_smiling_face: 

I think that GitHub Actions need to be enabled on the repo though