### PR TITLE
🐛 fix(tests/nn): use new name Conv2dBNReLU → ConvBlock

### DIFF
--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -49,10 +49,10 @@ def test_blocks():
     m = MConvBNReLU(4, 8, 3)
     m(torch.randn(1, 4, 8, 8))
 
-    m = Conv2dBNReLU(4, 8, 3)
+    m = ConvBlock(4, 8, 3)
     m(torch.randn(1, 4, 8, 8))
 
-    m = Conv2dBNReLU(4, 8, 3).remove_batchnorm().leaky()
+    m = ConvBlock(4, 8, 3).remove_batchnorm().leaky()
     m(torch.randn(1, 4, 8, 8))
 
     m = ResBlock(4, 8, 1)


### PR DESCRIPTION
d6cbc560e607c6301de47a572c6a9d56d001fb11 renamed `Conv2dBNReLU` but didn't update the tests accordingly. This PR fixes that