### PR TITLE
🔧 chore(flake8): add flake8 configuration file with some ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,16 @@
+[flake8]
+max-line-length = 80
+
+extend-ignore =
+    # W503 - because it's outdated and replaced by W504 while conflicting with it
+    W503,
+    # F401 - This is temporary, see https://github.com/Vermeille/Torchelie/issues/47
+    F401,
+    # E722 - This is temporary, see https://github.com/Vermeille/Torchelie/issues/48
+    E722,
+    # F405 - This is temporary, see https://github.com/Vermeille/Torchelie/issues/49
+    F405,
+    # F403 - This is temporary, see https://github.com/Vermeille/Torchelie/issues/49
+    F403,
+    # E501 - This is temporary, see https://github.com/Vermeille/Torchelie/issues/50
+    E501,

--- a/README.md
+++ b/README.md
@@ -284,8 +284,19 @@ pytest -m "not require_opencv"
 Code is formatted using [**YAPF**](https://github.com/google/yapf).
 
 For now, the CI doesn't check for code format, and the config files for yapf
-and linting aren't there, but do your best to format your code using YAPF (or
-at least comply with [**PEP8**](https://www.python.org/dev/peps/pep-0008/) 🙂)
+isn't there, but do your best to format your code using YAPF (or at least
+comply with [**PEP8**](https://www.python.org/dev/peps/pep-0008/) 🙂)
+
+## Lint
+
+Code is linted using [**Flake8**](https://pypi.org/project/flake8/). Do your
+best to send code that don't make it scream too loud 😉
+
+You can run it like this:
+
+```shell
+flake8 torchelie
+```
 
 ## Variable names
 


### PR DESCRIPTION
This PR bootstraps [Flake8](https://flake8.pycqa.org/en/latest/) configuration with a bunch of ignores related to currently opened issues.

As of today, this configuration ignores:

- 86 x  [F401 (_"Module imported but unused"_)](https://www.flake8rules.com/rules/F401.html) - See #47 
- 9 x [E722 (_"Do not use bare except, specify exception instead"_)](https://www.flake8rules.com/rules/E722.html) - See #48 
- 25 x [F405 (_"Name may be undefined, or defined from star imports: module"_)](https://www.flake8rules.com/rules/F405.html) - See #49
- 21 x [F403 (_"'from module import *' used; unable to detect undefined names"_)](https://www.flake8rules.com/rules/F403.html) - See #49
- 24 x [E501 (_"Line too long"_)](https://www.flake8rules.com/rules/E501.html) - See #50

With that, simply running `flake8 torchelie` without further filtering raises "only" 13 warnings :slightly_smiling_face: 