### PR TITLE
📝 docs(readme): add some pretty badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Torchélie
 
-![License](https://img.shields.io/github/license/Vermeille/Torchelie?color=informational&label=License)
+![License from GitHub](https://img.shields.io/github/license/Vermeille/Torchelie?color=informational&label=License)
 
-![Tests status](https://img.shields.io/github/workflow/status/Vermeille/Torchelie/Torch%C3%A9lie%20tests?label=Tests&logo=GitHub)
+![GitHub Actions - Tests status](https://img.shields.io/github/workflow/status/Vermeille/Torchelie/Torch%C3%A9lie%20tests?label=Tests&logo=GitHub)
 ![GitHub last commit](https://img.shields.io/github/last-commit/Vermeille/Torchelie?label=Last%20commit)
 
 <img src="https://github.com/Vermeille/Torchelie/blob/master/logo.png" height="200"/>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Torchélie
 
+![License](https://img.shields.io/github/license/Vermeille/Torchelie?color=informational&label=License)
+
 ![Tests status](https://img.shields.io/github/workflow/status/Vermeille/Torchelie/Torch%C3%A9lie%20tests?label=Tests&logo=GitHub)
 
 <img src="https://github.com/Vermeille/Torchelie/blob/master/logo.png" height="200"/>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![License](https://img.shields.io/github/license/Vermeille/Torchelie?color=informational&label=License)
 
 ![Tests status](https://img.shields.io/github/workflow/status/Vermeille/Torchelie/Torch%C3%A9lie%20tests?label=Tests&logo=GitHub)
+![GitHub last commit](https://img.shields.io/github/last-commit/Vermeille/Torchelie?label=Last%20commit)
 
 <img src="https://github.com/Vermeille/Torchelie/blob/master/logo.png" height="200"/>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Torchélie
 
+![Tests status](https://img.shields.io/github/workflow/status/Vermeille/Torchelie/Torch%C3%A9lie%20tests?label=Tests&logo=GitHub)
+
 <img src="https://github.com/Vermeille/Torchelie/blob/master/logo.png" height="200"/>
 
 Torchélie is a set of tools for pyTorch. It includes losses, optimizers,

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 ![GitHub Actions - Tests status](https://img.shields.io/github/workflow/status/Vermeille/Torchelie/Torch%C3%A9lie%20tests?label=Tests&logo=GitHub)
 ![GitHub last commit](https://img.shields.io/github/last-commit/Vermeille/Torchelie?label=Last%20commit)
+![Read the Docs build status](https://img.shields.io/readthedocs/torchelie?label=Read%20the%20Docs%20build%20status)
 
 Torchélie is a set of tools for pyTorch. It includes losses, optimizers,
 algorithms, utils, layers, models and training loops.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 <img src="https://github.com/Vermeille/Torchelie/blob/master/logo.png" height="200"/>
 
-![License from GitHub](https://img.shields.io/github/license/Vermeille/Torchelie?color=informational&label=License)
+[![License from GitHub](https://img.shields.io/github/license/Vermeille/Torchelie?color=informational&label=License)](https://github.com/Vermeille/Torchelie/blob/master/LICENSE)
 
-![GitHub Actions - Tests status](https://img.shields.io/github/workflow/status/Vermeille/Torchelie/Torch%C3%A9lie%20tests?label=Tests&logo=GitHub)
-![GitHub last commit](https://img.shields.io/github/last-commit/Vermeille/Torchelie?label=Last%20commit)
-![Read the Docs build status](https://img.shields.io/readthedocs/torchelie?label=Read%20the%20Docs%20build%20status)
+[![GitHub Actions - Tests status](https://img.shields.io/github/workflow/status/Vermeille/Torchelie/Torch%C3%A9lie%20tests?label=Tests&logo=GitHub)](https://github.com/Vermeille/Torchelie/actions/workflows/tests.yml?query=branch%3Amaster)
+[![GitHub last commit](https://img.shields.io/github/last-commit/Vermeille/Torchelie?label=Last%20commit)](https://github.com/Vermeille/Torchelie/commits/master)
+[![Read the Docs build status](https://img.shields.io/readthedocs/torchelie?label=Read%20the%20Docs%20build%20status)](https://torchelie.readthedocs.io)
 
 Torchélie is a set of tools for pyTorch. It includes losses, optimizers,
 algorithms, utils, layers, models and training loops.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Torchélie
 
+<img src="https://github.com/Vermeille/Torchelie/blob/master/logo.png" height="200"/>
+
 ![License from GitHub](https://img.shields.io/github/license/Vermeille/Torchelie?color=informational&label=License)
 
 ![GitHub Actions - Tests status](https://img.shields.io/github/workflow/status/Vermeille/Torchelie/Torch%C3%A9lie%20tests?label=Tests&logo=GitHub)
 ![GitHub last commit](https://img.shields.io/github/last-commit/Vermeille/Torchelie?label=Last%20commit)
-
-<img src="https://github.com/Vermeille/Torchelie/blob/master/logo.png" height="200"/>
 
 Torchélie is a set of tools for pyTorch. It includes losses, optimizers,
 algorithms, utils, layers, models and training loops.


### PR DESCRIPTION
This bootstrap the badges effort toward a pretty README :slightly_smiling_face: 

- The license badge pulls the license directly from GitHub metadata, and will be followed by other "informational" badges later on (such as supported Python versions, pypi download link, etc)
- The tests status badge helps in showing that the project is tested and that there's at least some CI in place, giving people more confidence in using it. It also helps in avoiding breaking the tests on master, since it will be publicly displayed on the README :wink: 
- The latest commit badge shows that the project is active, which is always something people are wondering (at least I often do). Not having to open the commit list or the "Insights" tab is always cool
- The readthedocs badge might help detect when something's wrong with readthedocs auto-build, and provides the links to the doc (even if, yes, it's already in the repo metadata as "website")